### PR TITLE
Matches can have multiple codes / "access profiles", some have less permissions than others

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Other commands:
 - Help: `np-scanner help`
 - Test poll: `np-scanner poll [game number or "all"]`
 - Disable match key: `np-scanner disable-player [game number] [player-id]`
+- Create a code that can only see data from player 1 and 2: `np-scanner protect --allowed-uid 1 --allowed-uid 2 [game number] [code]`
+- Replace all other codes: `np-scanner protect --wipe [game number] [code]`
 
 Config:
 

--- a/internal/cmd/protect.go
+++ b/internal/cmd/protect.go
@@ -4,11 +4,17 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"go.albinodrought.com/neptunes-pride/internal/matches"
+)
+
+var (
+	protectCmdWipe        bool
+	protectCmdAllowedUIDs []int
 )
 
 var protectCmd = &cobra.Command{
 	Use:   "protect [game number] [code]",
-	Short: "Protect a game with an access code",
+	Short: "Protect a game with an access profile",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		db, err := openDB()
@@ -21,9 +27,29 @@ var protectCmd = &cobra.Command{
 			log.Fatal("failed finding match: ", err)
 		}
 
-		err = match.SetAccessCode([]byte(args[1]))
+		if protectCmdWipe {
+			match.WipeAccessCodes()
+			log.Println("wiped old access code and profiles")
+		}
+
+		plaintext := []byte(args[1])
+
+		newProfile, err := matches.NewAccessProfile(plaintext)
 		if err != nil {
-			log.Fatal("failed setting access code: ", err)
+			log.Fatal("failed creating new access profile: ", err)
+		}
+
+		if len(protectCmdAllowedUIDs) > 0 {
+			log.Println("new profile can only view these players: ", protectCmdAllowedUIDs)
+			newProfile.AllowedPlayerIDs = protectCmdAllowedUIDs
+		} else {
+			log.Println("new profile can view every player")
+			newProfile.CanViewEveryPlayer = true
+		}
+
+		err = match.AddAccessProfile(newProfile, plaintext)
+		if err != nil {
+			log.Fatal("failed adding access profile: ", err)
 		}
 
 		err = db.SaveMatch(match)
@@ -33,4 +59,9 @@ var protectCmd = &cobra.Command{
 
 		log.Println("set access code for match", match.GameNumber, "to", args[1])
 	},
+}
+
+func init() {
+	protectCmd.Flags().BoolVar(&protectCmdWipe, "wipe", false, "Remove all other access profiles before adding this one")
+	protectCmd.Flags().IntSliceVar(&protectCmdAllowedUIDs, "allowed-uid", []int{}, "If set, access profile can only see these whitelisted users")
 }

--- a/internal/matches/matches.go
+++ b/internal/matches/matches.go
@@ -1,35 +1,131 @@
 package matches
 
 import (
+	"errors"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
 
+type AccessProfile struct {
+	Code               []byte
+	CanViewEveryPlayer bool
+	AllowedPlayerIDs   []int
+}
+
+func (ap *AccessProfile) CheckCode(plaintext []byte) error {
+	return bcrypt.CompareHashAndPassword(ap.Code, plaintext)
+}
+
+func (ap *AccessProfile) CanViewPlayerID(id int) bool {
+	if ap.CanViewEveryPlayer {
+		return true
+	}
+
+	if ap.AllowedPlayerIDs != nil {
+		for _, allowedPlayerID := range ap.AllowedPlayerIDs {
+			if id == allowedPlayerID {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func NewAccessProfile(plaintext []byte) (AccessProfile, error) {
+	hash, err := bcrypt.GenerateFromPassword(plaintext, bcrypt.DefaultCost)
+	return AccessProfile{
+		Code:             hash,
+		AllowedPlayerIDs: []int{},
+	}, err
+}
+
+func PermissiveAccessProfile() AccessProfile {
+	return AccessProfile{
+		CanViewEveryPlayer: true,
+		AllowedPlayerIDs:   []int{},
+	}
+}
+
 type Match struct {
-	GameNumber  string              `json:"game_number"`
-	Finished    bool                `json:"finished"`
-	Name        string              `json:"name"`
-	LastPoll    time.Time           `json:"last_poll"`
-	PlayerCreds map[int]PlayerCreds `json:"player_creds,omitempty"`
-	AccessCode  []byte              `json:"access_code,omitempty"`
+	GameNumber     string              `json:"game_number"`
+	Finished       bool                `json:"finished"`
+	Name           string              `json:"name"`
+	LastPoll       time.Time           `json:"last_poll"`
+	PlayerCreds    map[int]PlayerCreds `json:"player_creds,omitempty"`
+	OldAccessCode  []byte              `json:"access_code,omitempty"`
+	AccessProfiles []AccessProfile     `json:"access_profiles,omitempty"`
 }
 
 func (match *Match) HasAccessCode() bool {
-	return match.AccessCode != nil && len(match.AccessCode) > 0
+	// old access code
+	if match.OldAccessCode != nil && len(match.OldAccessCode) > 0 {
+		return true
+	}
+
+	// new access profiles
+	if match.AccessProfiles != nil && len(match.AccessProfiles) > 0 {
+		return true
+	}
+
+	return false
 }
 
-func (match *Match) SetAccessCode(plaintext []byte) error {
-	hash, err := bcrypt.GenerateFromPassword(plaintext, bcrypt.DefaultCost)
+var ErrNoAccessCodes = errors.New("no access codes to check")
+
+func (match *Match) CheckAccessCode(plaintext []byte) (AccessProfile, error) {
+	err := ErrNoAccessCodes
+
+	if match.OldAccessCode != nil {
+		accessProfile := PermissiveAccessProfile()
+		accessProfile.Code = match.OldAccessCode
+		err = accessProfile.CheckCode(plaintext)
+		if err == nil {
+			// old access code verified, return permissive access profile
+			return accessProfile, nil
+		}
+	}
+
+	if match.AccessProfiles != nil {
+		for _, accessProfile := range match.AccessProfiles {
+			err = accessProfile.CheckCode(plaintext)
+			if err == nil {
+				return accessProfile, nil
+			}
+		}
+	}
+
+	return AccessProfile{}, err
+}
+
+func (match *Match) WipeAccessCodes() {
+	match.OldAccessCode = nil
+	match.AccessProfiles = nil
+}
+
+var ErrAccessCodeAlreadyUsed = errors.New("access code is already used for another access profile")
+
+func (match *Match) AddAccessProfile(ap AccessProfile, plaintext []byte) error {
+	// plaintext must work for this profile
+	err := ap.CheckCode(plaintext)
 	if err != nil {
 		return err
 	}
-	match.AccessCode = hash
-	return nil
-}
 
-func (match *Match) CheckAccessCode(plaintext []byte) error {
-	return bcrypt.CompareHashAndPassword(match.AccessCode, plaintext)
+	if match.AccessProfiles == nil {
+		match.AccessProfiles = []AccessProfile{}
+	}
+
+	// ensure no other profiles already use this plaintext
+	_, err = match.CheckAccessCode(plaintext)
+	if err == nil {
+		return ErrAccessCodeAlreadyUsed
+	}
+
+	match.AccessProfiles = append(match.AccessProfiles, ap)
+
+	return nil
 }
 
 type PlayerCreds struct {


### PR DESCRIPTION
In a round where I want to share some data with some users, and other data with other users. 

This lets me generate one access profile for myself with all permissions:

`np-scanner protect 1234 SuperCode`

Another for the second player with permission to view only player 1:

`np-scanner protect --allowed-uid 1 1234 SomeCode`

And another for the third player with permission to view only players 1 and 2:

`np-scanner protect --allowed-uid 1 --allowed-uid 2 1234 OtherCode`